### PR TITLE
Add colors to groups to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ that doesn't diverge at any level (basically a linked list). I then
 merge all these individual trees into one large tree. Finally, I
 traverse the tree and generate group markers whenever I cross a module
 boundary.
+
+## Installing GTKWave on MacOS
+
+See [https://ughe.github.io/2018/11/06/gtkwave-osx](https://ughe.github.io/2018/11/06/gtkwave-osx)

--- a/addWavesRecursive.tcl
+++ b/addWavesRecursive.tcl
@@ -197,6 +197,9 @@ puts "\[sst_expanded\] 0"
 # some comment lines indicating the beginning of a new group ("vvvv")
 # and the end of a group ("^^^^").
 set oldNode -1
+set colorIncr 3
+set colorCounter 3
+set color 4
 foreach node [traverse $tree] {
     # This is broken for corner cases. What you want to do here is to
     # walk up the oldNode until you hit a common parent with the new
@@ -233,9 +236,16 @@ foreach node [traverse $tree] {
         puts "@22"
         push hier [join [absolutePath $tree $node] .]
         set oldNode $node
+	# Cycle through colors starting from green. Allowable color values are
+	# 1 = red, 2 = orange, 3 = yellow, 4 = green, 5 = blue, 6 = indigo,
+	# 7 = violet.
+	if {$colorIncr == -4} {set colorIncr 3} else {set colorIncr -4}
+	set colorCounter [expr [expr $colorCounter + $colorIncr] % 7]
+	set color [expr $colorCounter + 1]
         continue
     }
     # Print the current signal name.
+    puts "\[color\] $color"
     puts "[join [absolutePath $tree $node] .]"
     set oldNode $node
 }

--- a/addWavesRecursive.tcl
+++ b/addWavesRecursive.tcl
@@ -124,6 +124,10 @@ proc merge {tree subtree} {
 }
 
 #---------------------------------------- Main addWavesRecursive TCL script
+# print out start marker for awk (kludge needed when using gtkwave with -O flag
+# for output, as on MacOS)
+puts "STARTSTART"
+
 set nfacs [ gtkwave::getNumFacs ]
 set dumpname [ gtkwave::getDumpFileName ]
 set dmt [ gtkwave::getDumpType ]
@@ -245,8 +249,11 @@ foreach node [traverse $tree] {
         continue
     }
     # Print the current signal name.
-    puts "\[color\] $color"
-    puts "[join [absolutePath $tree $node] .]"
+    set signalName "[lindex [absolutePath $tree $node] end]"
+    if {[string match _* $signalName] == 0} {
+        puts "\[color\] $color"
+        puts "[join [absolutePath $tree $node] .]"
+    }
     set oldNode $node
 }
 # We're done, but the stack may still have entries, i.e., there are
@@ -257,6 +264,10 @@ foreach node $hier {
     puts "@22"
     puts "\[*\]^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
 }
+
+# print end marker (needed when gtkwave is run with -O flag). See above
+# comment about start marker
+puts "ENDEND"
 
 # We're done, so exit.
 gtkwave::/File/Quit

--- a/display-vcd.sh
+++ b/display-vcd.sh
@@ -15,8 +15,11 @@ HDL_SCRIPTS_DIR=~/dev/hdl-scripts
 VCD_FILE_BASE=$(basename ${VCD_FILE})
 MODULE_NAME="${VCD_FILE_BASE%.*}"
 VCD_DIR=$(dirname ${VCD_FILE})
+GTKW_TEMP_FILE=${VCD_DIR}/${MODULE_NAME}.gtkw.tmp
 GTKW_FILE=${VCD_DIR}/${MODULE_NAME}.gtkw
 
-gtkwave -S ${HDL_SCRIPTS_DIR}/addWavesRecursive.tcl ${VCD_FILE} > ${GTKW_FILE}
+gtkwave -S ${HDL_SCRIPTS_DIR}/addWavesRecursive.tcl ${VCD_FILE} -O ${GTKW_TEMP_FILE}
+awk -f take-after-start-marker.awk ${GTKW_TEMP_FILE} > ${GTKW_FILE}
+rm ${GTKW_TEMP_FILE}
 gtkwave ${VCD_FILE} ${GTKW_FILE}
 

--- a/display-vcd.sh
+++ b/display-vcd.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+usage() {
+	echo "Usage: display-vcd <vcd file>"
+}
+
+if [ "$#" -ne 1 ]; then
+	usage
+	exit 1
+fi
+
+VCD_FILE="$1"
+HDL_SCRIPTS_DIR=~/dev/hdl-scripts
+
+VCD_FILE_BASE=$(basename ${VCD_FILE})
+MODULE_NAME="${VCD_FILE_BASE%.*}"
+VCD_DIR=$(dirname ${VCD_FILE})
+GTKW_FILE=${VCD_DIR}/${MODULE_NAME}.gtkw
+
+gtkwave -S ${HDL_SCRIPTS_DIR}/addWavesRecursive.tcl ${VCD_FILE} > ${GTKW_FILE}
+gtkwave ${VCD_FILE} ${GTKW_FILE}
+

--- a/take-after-start-marker.awk
+++ b/take-after-start-marker.awk
@@ -1,0 +1,12 @@
+
+BEGIN {
+    begun = 0
+    done = 0
+}
+
+{
+    if ($0 ~ "ENDEND") done = 1
+    if (begun && !done) print $0
+    if ($0 ~ "STARTSTART") begun = 1
+}
+


### PR DESCRIPTION
In a trace with many signals, differentiating groups of related traces
with color can help the eye quickly locate the signals of interest. This
change adds color to each detected group of signals, cycling through
the seven available colors in an order that ensures that adjacent colors
contrast strongly.

